### PR TITLE
Migrated to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Useful if some process eats all your file descriptors.
 Tested on macOS and Ubuntu.
 
 Example:
+
 ```
 $ sudo lsof-offenders
 nopen:2525  pid:250   name:socketfilterfw
@@ -18,4 +19,14 @@ nopen:223   pid:45374 name:Dropbox
 
 ## Setup
 
-This is a Python 2 program. Install the package `pip install psutil`. `lsof-offenders` must run as sudo, so make sure to install `psutil` for whatever version of python you will be running as root.
+This python program depends on the [psutil](https://github.com/giampaolo/psutil) package and must run with root privileges:
+
+```
+$ pip install psutil
+```
+
+Make it available systemwide by putting it in your binary executable path:
+
+```
+$ cp lsof-offenders /usr/local/bin/
+```

--- a/lsof-offenders
+++ b/lsof-offenders
@@ -34,11 +34,11 @@ try:
         except psutil.NoSuchProcess:
             n_disappeared += 1
     for psum in sorted(process_summaries, key=lambda psum: -psum.num_fds)[:20]:
-        print "nopen:{:<5} pid:{:<5} name:{}".format(psum.num_fds, psum.pid, psum.name)
+        print("nopen:{:<5} pid:{:<5} name:{}".format(psum.num_fds, psum.pid, psum.name))
     if n_zombies > 0:
-        print "zombies: {}".format(n_zombies)
+        print("zombies: {}".format(n_zombies))
     if n_disappeared > 0:
-        print "disappeared: {}".format(n_disappeared)
+        print("disappeared: {}".format(n_disappeared))
 except psutil.AccessDenied as ex:
-    print ex
-    print "sudo is required"
+    print(ex)
+    print("sudo is required")


### PR DESCRIPTION
Handy little utility.  Who knew [ipfs](https://github.com/ipfs/ipfs) was hogging my file descriptors?

Still works with Python 2!

```
$ sudo ./lsof-offenders
Password:
nopen:862   pid:852   name:ipfs
nopen:248   pid:639   name:Google Chrome
nopen:161   pid:636   name:Opera
nopen:146   pid:56    name:UserEventAgent
nopen:136   pid:6167  name:firefox
nopen:93    pid:642   name:Beaker Browser
nopen:81    pid:393   name:nsurlstoraged
nopen:76    pid:368   name:UserEventAgent
nopen:67    pid:836   name:AppleSpell
nopen:62    pid:640   name:Messenger for Desktop
nopen:58    pid:186   name:mDNSResponder
nopen:56    pid:57431 name:Slack
nopen:55    pid:2835  name:Keybase
nopen:54    pid:130   name:notifyd
nopen:51    pid:1     name:launchd
nopen:45    pid:266   name:mds_stores
nopen:41    pid:381   name:CalendarAgent
nopen:41    pid:2878  name:kbfs
nopen:41    pid:68965 name:awdd
nopen:36    pid:866   name:Quicksilver
zombies: 11
```